### PR TITLE
Fix whoami test failures in CI

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    env: { NO_COLOR: '1' },
     include: ['tests/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- Set `NO_COLOR=1` in vitest config so picocolors outputs plain text during tests
- ANSI color codes around formatted numbers (e.g. `\u001b[32m4,821\u001b[39m followers`) broke `toContain` assertions in CI where color detection differs from local

## Test plan
- [x] CI passes on this PR
- [ ] Merge and verify main branch CI goes green