### PR TITLE
ci: fix trusted publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
+
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
 
       - run: pnpm install --frozen-lockfile
       - run: npm run check
@@ -47,7 +51,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Push semver GitHub tag


### PR DESCRIPTION
## Summary
- upgrade npm in release workflow to >=11.5.1 for npm trusted publishing support
- stop forcing an empty NODE_AUTH_TOKEN into the publish step

## Validation
- npm run check
- npm run security
- bash scripts/check-docs.sh