### PR TITLE
ci: auto-generate rich release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,117 @@ jobs:
           fi
           git tag "$VERSION"
           git push origin "$VERSION"
+
+      - name: Generate rich release notes
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("node:fs");
+
+            const { owner, repo } = context.repo;
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const currentTag = `v${pkg.version}`;
+
+            const release = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag: currentTag,
+            });
+
+            const tags = await github.paginate(github.rest.repos.listTags, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const currentTagIndex = tags.findIndex((tag) => tag.name === currentTag);
+            let baseRef = null;
+
+            if (currentTagIndex >= 0 && currentTagIndex + 1 < tags.length) {
+              baseRef = tags[currentTagIndex + 1].name;
+            } else {
+              const commits = await github.paginate(github.rest.repos.listCommits, {
+                owner,
+                repo,
+                per_page: 100,
+              });
+              baseRef = commits.at(-1)?.sha ?? null;
+            }
+
+            if (!baseRef) {
+              core.warning("Could not determine comparison base; skipping release note update.");
+              return;
+            }
+
+            const comparison = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: baseRef,
+              head: currentTag,
+            });
+
+            const commits = comparison.data.commits ?? [];
+
+            const commitLog = commits.map((commit) => {
+              const subject = (commit.commit.message || "").split("\n")[0];
+              return `- ${commit.sha.slice(0, 7)} ${subject}`;
+            });
+
+            const contributorSet = new Set(
+              commits
+                .map((commit) => commit.author?.login)
+                .filter((login) => Boolean(login))
+                .map((login) => `@${login}`)
+            );
+
+            const prNumbers = new Set();
+            const prPattern = /#(\d+)/g;
+
+            for (const commit of commits) {
+              const subject = (commit.commit.message || "").split("\n")[0];
+              for (const match of subject.matchAll(prPattern)) {
+                prNumbers.add(Number(match[1]));
+              }
+            }
+
+            const pullRequests = [];
+
+            for (const number of Array.from(prNumbers).sort((a, b) => b - a)) {
+              try {
+                const pr = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: number,
+                });
+                pullRequests.push(`- #${number} ${pr.data.title}`);
+              } catch (error) {
+                core.info(`Skipping #${number}; could not load pull request details.`);
+              }
+            }
+
+            const sections = [
+              "## Changelog",
+              "",
+              "### Pull Requests",
+              ...(pullRequests.length > 0 ? pullRequests : ["- none"]),
+              "",
+              "### Commit Log",
+              ...(commitLog.length > 0 ? commitLog : ["- none"]),
+              "",
+              "### Contributors",
+              ...(contributorSet.size > 0 ? Array.from(contributorSet).sort() : ["- unknown"]),
+              "",
+              `**Full diff:** ${comparison.data.html_url}`,
+            ];
+
+            const body = sections.join("\n");
+
+            await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: release.data.id,
+              tag_name: currentTag,
+              name: release.data.name || currentTag,
+              body,
+            });

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ A few ground rules:
 - Merge PRs to `main` as usual.
 - The `Release` GitHub Action opens/updates a release PR with version bumps + `CHANGELOG.md`.
 - Merging that release PR publishes to npm and creates a GitHub release.
+- Release notes are auto-generated with pull requests, commit log, contributors, and a compare link.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
- add a post-publish release workflow step that rewrites GitHub release notes with PRs, commits, contributors, and full diff link
- keep existing Changesets release flow intact (publish + tag + GitHub release)
- document auto-generated release note format in README

## Validation
- bash scripts/check-docs.sh
- pre-push hooks: npm run check, npm run security