### PR TITLE
fix(profile): resolve no-scheme URLs and ignore placeholder URN drift

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,7 +1,12 @@
 # Memory Log
-Last Updated: 2026-02-25
+Last Updated: 2026-02-27
 
 Append-only log. Add entries; do not rewrite historical entries except typo fixes.
+
+## 2026-02-27
+- Correction: `profile` treated no-scheme LinkedIn URLs (for example `linkedin.com/in/<handle>`) as plain usernames, so recipient resolution requested invalid member identities and returned `Invalid request`.
+- Fix: updated URL parsing to normalize no-scheme LinkedIn URLs before route parsing, and added tests for no-scheme supported/unsupported paths.
+- Guardrail: recipient cache warnings now ignore synthetic/non-canonical URNs (for example fixture-style placeholders) and tests use isolated cache paths to prevent cross-run cache contamination.
 
 ## 2026-02-25
 - Correction: process guidance was fragmented across root markdown files and drifted over time.

--- a/src/lib/url-parser.ts
+++ b/src/lib/url-parser.ts
@@ -47,6 +47,11 @@ export function parseLinkedInUrl(input: string): ParsedLinkedInUrl | null {
 		return parseUrl(trimmed);
 	}
 
+	// Handle LinkedIn URLs pasted without a scheme (e.g. linkedin.com/in/user)
+	if (isLikelyLinkedInUrlWithoutScheme(trimmed)) {
+		return parseUrl(`https://${trimmed}`);
+	}
+
 	// Treat as plain username (for profile lookups)
 	return {
 		type: "profile",
@@ -104,7 +109,7 @@ function parseUrl(urlString: string): ParsedLinkedInUrl | null {
 
 	// Validate it's a LinkedIn domain
 	const hostname = url.hostname.toLowerCase();
-	if (!hostname.endsWith("linkedin.com") && hostname !== "linkedin.com") {
+	if (hostname !== "linkedin.com" && !hostname.endsWith(".linkedin.com")) {
 		return null;
 	}
 
@@ -144,6 +149,10 @@ function parseUrl(urlString: string): ParsedLinkedInUrl | null {
 	}
 
 	return null;
+}
+
+function isLikelyLinkedInUrlWithoutScheme(input: string): boolean {
+	return /^(?:[a-z0-9-]+\.)*linkedin\.com(?:\/|$)/i.test(input);
 }
 
 /**

--- a/tests/unit/url-parser.test.ts
+++ b/tests/unit/url-parser.test.ts
@@ -55,6 +55,15 @@ describe("url-parser", () => {
 				});
 			});
 
+			it("handles linkedin.com profile URLs without scheme", () => {
+				const result = parseLinkedInUrl("linkedin.com/in/peggyrayzis");
+
+				expect(result).toEqual({
+					type: "profile",
+					identifier: "peggyrayzis",
+				});
+			});
+
 			it("handles mobile linkedin URLs (m.linkedin.com)", () => {
 				const result = parseLinkedInUrl("https://m.linkedin.com/in/peggyrayzis");
 
@@ -337,8 +346,19 @@ describe("url-parser", () => {
 				expect(result).toBeNull();
 			});
 
+			it("returns null for domains that only suffix-match linkedin.com", () => {
+				expect(parseLinkedInUrl("https://notlinkedin.com/in/peggyrayzis")).toBeNull();
+				expect(parseLinkedInUrl("https://evil-linkedin.com/in/peggyrayzis")).toBeNull();
+			});
+
 			it("returns null for LinkedIn URL with unsupported path", () => {
 				const result = parseLinkedInUrl("https://www.linkedin.com/learning");
+
+				expect(result).toBeNull();
+			});
+
+			it("returns null for no-scheme LinkedIn URL with unsupported path", () => {
+				const result = parseLinkedInUrl("linkedin.com/learning");
 
 				expect(result).toBeNull();
 			});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,15 @@
+import os from 'node:os'
+import path from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    env: { NO_COLOR: '1' },
+    env: {
+      NO_COLOR: '1',
+      LI_RECIPIENT_CACHE_PATH: path.join(os.tmpdir(), `li-recipient-cache-vitest-${process.pid}.json`),
+    },
     include: ['tests/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Closes #
Closes #20

## Description
Fixes two `li profile` regressions in production: no-scheme profile URLs were parsed as raw usernames, and recipient cache drift warnings could surface synthetic placeholder URNs.

## Summary
- Normalize no-scheme LinkedIn URLs in `parseLinkedInUrl` (for example `linkedin.com/in/<handle>`).
- Tighten LinkedIn hostname validation to `linkedin.com` or `*.linkedin.com` only.
- Filter recipient cache warning comparisons to canonical URNs (`urn:li:member:<digits>` or `urn:li:fsd_profile:ACo...`) so placeholder cache values do not emit false drift warnings.
- Resolve recipient-cache path lazily from env to make tests/processes isolate cache files safely.
- Add regression coverage for no-scheme URLs, malicious suffix-match hostnames, no-scheme recipient resolution, and warning behavior with placeholder vs valid cached URNs.
- Isolate Vitest recipient cache path to avoid polluting user-level temp cache between test and production runs.
- Append a memory-log entry for the regression/fix.

## Checks
- [x] npm run check
- [x] npm run security
- [x] bash scripts/check-docs.sh

## Review
- [x] Reviewer findings addressed or documented
- [x] Residual risks documented

## Residual Risks
- Canonical URN filtering intentionally treats non-`ACo...` `fsd_profile` IDs as non-cacheable; if LinkedIn introduces a new profile-ID shape, warnings for that shape will be suppressed until patterns are updated.
- Integration tests for this path remain skipped unless auth-backed test env is enabled.
